### PR TITLE
Fix header.filesz calculation

### DIFF
--- a/test_main.c
+++ b/test_main.c
@@ -6,7 +6,7 @@
  */
 
 #include "elfcore.h"
-
+#include <string.h>
 
 void test_elfcore(void);
 
@@ -17,6 +17,7 @@ Frame core_frame;
 
 void test_elfcore()
 {
+    memset(core_buf, 0xde, sizeof(core_buf));
     CreateElfCore("core", 0x1fffc000, (uint8_t *)core_buf, 32*1024, &core_frame);
 }
 


### PR DESCRIPTION
This yields a correct readelf -a output on the core dump.
This also allows gdb to recognise the file as a core dump, arm-none-eabi-gdb now prints:
"/home/thomas/tmp/bare_core/core": no core file handler recognizes format
instead of
"/home/thomas/tmp/bare_core/core" is not a core dump: File format not recognized

Before arm-none-eabi-gdb can read the core file, binutils-gdb/gdb/arm-tdep.c needs to
have core dump support implemented.